### PR TITLE
"Bypass Time" added + 1.18.1 compatibility

### DIFF
--- a/src/ptl/ajneb97/PlayerTimeLimit.java
+++ b/src/ptl/ajneb97/PlayerTimeLimit.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;

--- a/src/ptl/ajneb97/api/ExpansionPlayerTimeLimit.java
+++ b/src/ptl/ajneb97/api/ExpansionPlayerTimeLimit.java
@@ -1,7 +1,5 @@
 package ptl.ajneb97.api;
 
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;

--- a/src/ptl/ajneb97/api/PlayerTimeLimitAPI.java
+++ b/src/ptl/ajneb97/api/PlayerTimeLimitAPI.java
@@ -10,6 +10,7 @@ import ptl.ajneb97.utils.UtilsTime;
 public class PlayerTimeLimitAPI {
 
 	private static PlayerTimeLimit plugin;
+	@SuppressWarnings("static-access")
 	public PlayerTimeLimitAPI(PlayerTimeLimit plugin) {
 		this.plugin = plugin;
 	}

--- a/src/ptl/ajneb97/configs/MainConfigManager.java
+++ b/src/ptl/ajneb97/configs/MainConfigManager.java
@@ -4,7 +4,6 @@ package ptl.ajneb97.configs;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import ptl.ajneb97.PlayerTimeLimit;

--- a/src/ptl/ajneb97/libs/actionbar/ActionBarAPI.java
+++ b/src/ptl/ajneb97/libs/actionbar/ActionBarAPI.java
@@ -2,6 +2,7 @@ package ptl.ajneb97.libs.actionbar;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -87,7 +88,6 @@ public class ActionBarAPI
 		if (duration >= 0) {
 			// Sends empty message at the end of the duration. Allows messages shorter than 3 seconds, ensures precision.
 			new BukkitRunnable() {
-				@Override
 				public void run() {
 					sendActionBar(player, "");
 				}
@@ -98,7 +98,6 @@ public class ActionBarAPI
 		while (duration > 40) {
 			duration -= 40;
 			new BukkitRunnable() {
-				@Override
 				public void run() {
 					sendActionBar(player, message);
 				}

--- a/src/ptl/ajneb97/listeners/PlayerListener.java
+++ b/src/ptl/ajneb97/listeners/PlayerListener.java
@@ -1,9 +1,7 @@
 package ptl.ajneb97.listeners;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -20,10 +18,10 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 import ptl.ajneb97.PlayerTimeLimit;
 import ptl.ajneb97.configs.MainConfigManager;
-import ptl.ajneb97.configs.others.TimeLimit;
 import ptl.ajneb97.managers.MensajesManager;
 import ptl.ajneb97.managers.PlayerManager;
 import ptl.ajneb97.model.TimeLimitPlayer;
+import ptl.ajneb97.utils.BypassTimes;
 
 public class PlayerListener implements Listener{
 
@@ -47,7 +45,7 @@ public class PlayerListener implements Listener{
 			
 			int currentTime = p.getCurrentTime();
 			int timeLimit = playerManager.getTimeLimitPlayer(player);
-			if(currentTime >= timeLimit && timeLimit != 0) {
+			if(currentTime >= timeLimit && timeLimit != 0 && !BypassTimes.isBypassNow(plugin)) {
 				FileConfiguration messages = plugin.getMessages();
 				List<String> msg = messages.getStringList("joinErrorMessage");
 				String finalMessage = "";

--- a/src/ptl/ajneb97/managers/MensajesManager.java
+++ b/src/ptl/ajneb97/managers/MensajesManager.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+
 import net.md_5.bungee.api.ChatColor;
 import ptl.ajneb97.libs.centeredmessages.DefaultFontInfo;
 

--- a/src/ptl/ajneb97/managers/PlayerManager.java
+++ b/src/ptl/ajneb97/managers/PlayerManager.java
@@ -3,9 +3,7 @@ package ptl.ajneb97.managers;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -16,6 +14,7 @@ import ptl.ajneb97.PlayerTimeLimit;
 import ptl.ajneb97.configs.MainConfigManager;
 import ptl.ajneb97.configs.others.TimeLimit;
 import ptl.ajneb97.model.TimeLimitPlayer;
+import ptl.ajneb97.utils.BypassTimes;
 import ptl.ajneb97.utils.UtilsTime;
 
 public class PlayerManager {
@@ -71,7 +70,6 @@ public class PlayerManager {
 		//El jugador ya ha completado su tiempo
 		final FileConfiguration messages = plugin.getMessages();
 		new BukkitRunnable() {
-			@Override
 			public void run() {
 				MainConfigManager mainConfig = plugin.getConfigsManager().getMainConfigManager();
 				if(mainConfig.isWorldWhitelistEnabled()) {
@@ -99,7 +97,7 @@ public class PlayerManager {
 	public boolean hasTimeLeft(TimeLimitPlayer p) {
 		int currentTime = p.getCurrentTime();
 		int timeLimit = getTimeLimitPlayer(p.getPlayer());
-		if(currentTime < timeLimit || timeLimit == 0) {
+		if(currentTime < timeLimit || timeLimit == 0 || BypassTimes.isBypassNow(plugin)) {
 			return true;
 		}
 		return false;

--- a/src/ptl/ajneb97/managers/ServerManager.java
+++ b/src/ptl/ajneb97/managers/ServerManager.java
@@ -1,19 +1,12 @@
 package ptl.ajneb97.managers;
 
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
-import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import ptl.ajneb97.PlayerTimeLimit;
 import ptl.ajneb97.configs.MainConfigManager;
-import ptl.ajneb97.model.TimeLimitPlayer;
 import ptl.ajneb97.utils.UtilsTime;
 
 public class ServerManager {

--- a/src/ptl/ajneb97/tasks/DataSaveTask.java
+++ b/src/ptl/ajneb97/tasks/DataSaveTask.java
@@ -21,7 +21,6 @@ public class DataSaveTask {
 		long ticks = minutes*60*20;
 		
 		new BukkitRunnable() {
-			@Override
 			public void run() {
 				if(end) {
 					this.cancel();

--- a/src/ptl/ajneb97/tasks/PlayerTimeTask.java
+++ b/src/ptl/ajneb97/tasks/PlayerTimeTask.java
@@ -1,6 +1,9 @@
 package ptl.ajneb97.tasks;
 
-import java.util.ArrayList;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 
 import org.bukkit.Bukkit;
@@ -14,14 +17,13 @@ import org.bukkit.scheduler.BukkitRunnable;
 import ptl.ajneb97.PlayerTimeLimit;
 import ptl.ajneb97.configs.MainConfigManager;
 import ptl.ajneb97.configs.others.Notification;
-import ptl.ajneb97.configs.others.TimeLimit;
 import ptl.ajneb97.libs.actionbar.ActionBarAPI;
 import ptl.ajneb97.libs.bossbar.BossBarAPI;
 import ptl.ajneb97.managers.MensajesManager;
 import ptl.ajneb97.managers.PlayerManager;
 import ptl.ajneb97.managers.ServerManager;
 import ptl.ajneb97.model.TimeLimitPlayer;
-import ptl.ajneb97.utils.UtilsTime;
+import ptl.ajneb97.utils.BypassTimes;
 
 public class PlayerTimeTask {
 
@@ -32,7 +34,6 @@ public class PlayerTimeTask {
 	
 	public void start() {
 		new BukkitRunnable() {
-			@Override
 			public void run() {
 				execute();
 			}
@@ -42,7 +43,6 @@ public class PlayerTimeTask {
 	
 	public void execute() {
 		new BukkitRunnable() {
-			@Override
 			public void run() {
 				MainConfigManager mainConfig = plugin.getConfigsManager().getMainConfigManager();
 
@@ -62,7 +62,10 @@ public class PlayerTimeTask {
 							p.eliminarBossBar();
 							continue;
 						}
-						p.increaseTime();
+
+						if(!BypassTimes.isBypassNow(plugin))
+							p.increaseTime();
+						
 						sendActionBar(player,p,actionBar);
 						sendBossBar(player,p,bossBar,bossBarColor,bossBarStyle);
 						sendNotification(player,p,mainConfig);

--- a/src/ptl/ajneb97/tasks/ServerTimeResetTask.java
+++ b/src/ptl/ajneb97/tasks/ServerTimeResetTask.java
@@ -2,14 +2,11 @@ package ptl.ajneb97.tasks;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 
-import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import ptl.ajneb97.PlayerTimeLimit;
 import ptl.ajneb97.configs.MainConfigManager;
-import ptl.ajneb97.model.TimeLimitPlayer;
 
 public class ServerTimeResetTask {
 
@@ -22,7 +19,6 @@ public class ServerTimeResetTask {
 	
 	public void start() {
 		new BukkitRunnable() {
-			@Override
 			public void run() {
 				execute();
 			}
@@ -39,7 +35,6 @@ public class ServerTimeResetTask {
 		if(resetTime.equals(currentTime)) {
 			//REINICIO DE TIEMPO
 			new BukkitRunnable() {
-				@Override
 				public void run() {
 					plugin.getPlayerManager().resetPlayers();
 				}

--- a/src/ptl/ajneb97/utils/BypassTimes.java
+++ b/src/ptl/ajneb97/utils/BypassTimes.java
@@ -1,0 +1,46 @@
+package ptl.ajneb97.utils;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import ptl.ajneb97.PlayerTimeLimit;
+
+public class BypassTimes {
+
+	public static boolean isBypassNow(PlayerTimeLimit plugin) {
+
+		if (plugin.getConfig().contains("bypass_time")) {
+			for (String name : plugin.getConfig().getConfigurationSection("bypass_time").getKeys(false)) {
+
+				SimpleDateFormat parser = new SimpleDateFormat("HH:mm");
+
+				DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
+				LocalDateTime now = LocalDateTime.now();
+				String currentTime = dtf.format(now);
+
+				try {
+					Date curTime = parser.parse(currentTime);
+					Date start = parser.parse((String) plugin.getConfig().getConfigurationSection("bypass_time")
+							.getConfigurationSection(name).get("start"));
+					Date end = parser.parse((String) plugin.getConfig().getConfigurationSection("bypass_time")
+							.getConfigurationSection(name).get("end"));
+
+					if (curTime.after(start) && curTime.before(end)) {
+						return true;
+					}
+
+				} catch (Exception e) {
+					System.out.println(
+							"[PlayerTimeLimit] There were some errors within the bypass calculation. Please double-check your config file");
+				}
+				return false;
+			}
+
+		}
+
+		return false;
+	}
+
+}

--- a/src/ptl/ajneb97/utils/UtilsTime.java
+++ b/src/ptl/ajneb97/utils/UtilsTime.java
@@ -2,8 +2,6 @@ package ptl.ajneb97.utils;
 
 import java.util.Calendar;
 
-import org.bukkit.Bukkit;
-
 import ptl.ajneb97.managers.MensajesManager;
 
 public class UtilsTime {


### PR DESCRIPTION
- Added setting for periods in which no time is deducted
- Organized imports
- Tested and upgraded to 1.18.1 compatibility