### PR TITLE
Fix AuthMe login window: pause time tracking pre-auth and recalc on a…

### DIFF
--- a/src/main/java/ptl/ajneb97/PlayerTimeLimit.java
+++ b/src/main/java/ptl/ajneb97/PlayerTimeLimit.java
@@ -17,6 +17,7 @@ import ptl.ajneb97.managers.dependencies.DependencyManager;
 import ptl.ajneb97.managers.dependencies.Metrics;
 import ptl.ajneb97.model.internal.UpdateCheckerResult;
 import ptl.ajneb97.tasks.*;
+import ptl.ajneb97.integrations.AuthMeSupport;
 import ptl.ajneb97.utils.ServerVersion;
 
 
@@ -34,6 +35,7 @@ public class PlayerTimeLimit extends JavaPlugin {
 	private DependencyManager dependencyManager;
 	private TimeResetManager timeResetManager;
 	private DatabaseManager databaseManager;
+	private AuthMeSupport authMeSupport;
 	
 	private PlayerDataSaveTask playerDataSaveTask;
 	private PlayerTimeTask playerTimeTask;
@@ -55,6 +57,8 @@ public class PlayerTimeLimit extends JavaPlugin {
 
 		registerEvents();
 		registerCommands();
+		this.authMeSupport = new AuthMeSupport(this);
+		this.authMeSupport.registerAuthEvents();
 
 		playerTimeTask = new PlayerTimeTask(this);
 		playerTimeTask.start();
@@ -184,5 +188,9 @@ public class PlayerTimeLimit extends JavaPlugin {
 
 	public UpdateCheckerManager getUpdateCheckerManager() {
 		return updateCheckerManager;
+	}
+
+	public AuthMeSupport getAuthMeSupport() {
+		return authMeSupport;
 	}
 }

--- a/src/main/java/ptl/ajneb97/integrations/AuthMeSupport.java
+++ b/src/main/java/ptl/ajneb97/integrations/AuthMeSupport.java
@@ -1,0 +1,153 @@
+package ptl.ajneb97.integrations;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.PluginManager;
+import ptl.ajneb97.PlayerTimeLimit;
+import ptl.ajneb97.configs.MainConfigManager;
+import ptl.ajneb97.managers.PlayerDataManager;
+import ptl.ajneb97.managers.PlayerTimeManager;
+
+import java.lang.reflect.Method;
+
+public class AuthMeSupport {
+
+    private static final String AUTHME_PLUGIN_NAME = "AuthMe";
+    private static final String AUTHME_API_CLASS = "fr.xephi.authme.api.v3.AuthMeApi";
+    private static final String AUTHME_LOGIN_EVENT = "fr.xephi.authme.events.LoginEvent";
+    private static final String AUTHME_RESTORE_SESSION_EVENT = "fr.xephi.authme.events.RestoreSessionEvent";
+    private static final String AUTHME_REGISTER_EVENT = "fr.xephi.authme.events.RegisterEvent";
+
+    private final PlayerTimeLimit plugin;
+
+    private final boolean authMePresent;
+    private Method apiGetInstanceMethod;
+    private Method isAuthenticatedMethod;
+    private Method isRegisteredMethod;
+    private Object authMeApiInstance;
+    private boolean apiLoaded;
+
+    public AuthMeSupport(PlayerTimeLimit plugin) {
+        this.plugin = plugin;
+        this.authMePresent = Bukkit.getPluginManager().getPlugin(AUTHME_PLUGIN_NAME) != null;
+        if (authMePresent) {
+            loadApi();
+        }
+    }
+
+    public boolean isReadyForTimeTracking(Player player) {
+        if (!authMePresent) {
+            return true;
+        }
+        if (player == null || !player.isOnline()) {
+            return false;
+        }
+        if (!apiLoaded && !loadApi()) {
+            return false;
+        }
+
+        try {
+            boolean authenticated = (boolean) isAuthenticatedMethod.invoke(authMeApiInstance, player);
+            if (authenticated) {
+                return true;
+            }
+
+            boolean registered = (boolean) isRegisteredMethod.invoke(authMeApiInstance, player.getName());
+            return !registered;
+        } catch (ReflectiveOperationException e) {
+            plugin.getLogger().warning("AuthMe API invocation failed while checking auth state: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public void registerAuthEvents() {
+        if (!authMePresent) {
+            return;
+        }
+
+        registerAuthEvent(AUTHME_LOGIN_EVENT);
+        registerAuthEvent(AUTHME_RESTORE_SESSION_EVENT);
+        registerAuthEvent(AUTHME_REGISTER_EVENT);
+    }
+
+    private boolean loadApi() {
+        try {
+            Class<?> apiClass = Class.forName(AUTHME_API_CLASS);
+            apiGetInstanceMethod = apiClass.getMethod("getInstance");
+            isAuthenticatedMethod = apiClass.getMethod("isAuthenticated", Player.class);
+            isRegisteredMethod = apiClass.getMethod("isRegistered", String.class);
+            authMeApiInstance = apiGetInstanceMethod.invoke(null);
+            apiLoaded = authMeApiInstance != null;
+            if (!apiLoaded) {
+                plugin.getLogger().warning("AuthMe API instance is null; delaying auth checks.");
+            }
+            return apiLoaded;
+        } catch (ReflectiveOperationException e) {
+            plugin.getLogger().warning("Could not load AuthMe API v3 support: " + e.getMessage());
+            apiLoaded = false;
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerAuthEvent(String eventClassName) {
+        try {
+            Class<?> rawEventClass = Class.forName(eventClassName);
+            if (!Event.class.isAssignableFrom(rawEventClass)) {
+                return;
+            }
+
+            Class<? extends Event> eventClass = (Class<? extends Event>) rawEventClass;
+            Listener listener = new Listener() {
+            };
+
+            PluginManager pluginManager = Bukkit.getPluginManager();
+            pluginManager.registerEvent(eventClass, listener, EventPriority.MONITOR, (registeredListener, event) -> {
+                Player player = extractPlayer(event);
+                if (player == null) {
+                    return;
+                }
+                runSync(() -> refreshAfterAuthentication(player));
+            }, plugin, true);
+        } catch (ClassNotFoundException ignored) {
+            // AuthMe variant may not expose all events; this is optional.
+        }
+    }
+
+    private Player extractPlayer(Event event) {
+        try {
+            Method getPlayer = event.getClass().getMethod("getPlayer");
+            Object result = getPlayer.invoke(event);
+            if (result instanceof Player player) {
+                return player;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Ignore unsupported event signatures.
+        }
+        return null;
+    }
+
+    private void runSync(Runnable action) {
+        if (Bukkit.isPrimaryThread()) {
+            action.run();
+        } else {
+            Bukkit.getScheduler().runTask(plugin, action);
+        }
+    }
+
+    private void refreshAfterAuthentication(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+
+        PlayerDataManager playerDataManager = plugin.getPlayerDataManager();
+        PlayerTimeManager playerTimeManager = plugin.getPlayerTimeManager();
+        MainConfigManager mainConfigManager = plugin.getConfigsManager().getMainConfigManager();
+
+        playerDataManager.updateTimeLimit(player);
+        playerTimeManager.sendInfoBars(player, playerDataManager, mainConfigManager);
+    }
+}

--- a/src/main/java/ptl/ajneb97/managers/PlayerDataManager.java
+++ b/src/main/java/ptl/ajneb97/managers/PlayerDataManager.java
@@ -126,7 +126,9 @@ public class PlayerDataManager {
         if(playerData == null){
             createPlayer(player);
         }
-        updateTimeLimit(player);
+        if(isReadyForTimeTracking(player)) {
+            updateTimeLimit(player);
+        }
     }
 
     public void manageLeave(Player player){
@@ -172,6 +174,13 @@ public class PlayerDataManager {
         if(!playerData.getTimeLimit().equals(timeLimitName)){
             playerData.setTimeLimit(timeLimitName);
         }
+    }
+
+    public boolean isReadyForTimeTracking(Player player) {
+        if (player == null || !player.isOnline()) {
+            return false;
+        }
+        return plugin.getAuthMeSupport() == null || plugin.getAuthMeSupport().isReadyForTimeTracking(player);
     }
 
     public int getTimeLimit(UUID uuid) {

--- a/src/main/java/ptl/ajneb97/tasks/PlayerTimeTask.java
+++ b/src/main/java/ptl/ajneb97/tasks/PlayerTimeTask.java
@@ -27,8 +27,11 @@ public class PlayerTimeTask {
 	public void execute() {
 		MainConfigManager mainConfigManager = plugin.getConfigsManager().getMainConfigManager();
 		PlayerTimeManager playerTimeManager = plugin.getPlayerTimeManager();
+		var playerDataManager = plugin.getPlayerDataManager();
 		for(Player player : Bukkit.getOnlinePlayers()){
-			playerTimeManager.updateTimePlayer(player,mainConfigManager);
+			if(playerDataManager.isReadyForTimeTracking(player)) {
+				playerTimeManager.updateTimePlayer(player,mainConfigManager);
+			}
 		}
 	}
 

--- a/src/main/java/ptl/ajneb97/tasks/PlayerUpdateLimitTask.java
+++ b/src/main/java/ptl/ajneb97/tasks/PlayerUpdateLimitTask.java
@@ -20,13 +20,15 @@ public class PlayerUpdateLimitTask {
                 execute();
             }
 
-        }.runTaskTimerAsynchronously(plugin, 0L, 60L);
+        }.runTaskTimer(plugin, 0L, 60L);
     }
 
     public void execute() {
         PlayerDataManager playerDataManager = plugin.getPlayerDataManager();
         for(Player player : Bukkit.getOnlinePlayers()){
-            playerDataManager.updateTimeLimit(player);
+            if(playerDataManager.isReadyForTimeTracking(player)) {
+                playerDataManager.updateTimeLimit(player);
+            }
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 name: PlayerTimeLimit
 api-version: 1.13
 author: Ajneb97
-softdepend: [Multiverse-Core,PlaceholderAPI]
+softdepend: [Multiverse-Core,PlaceholderAPI,AuthMe]
 
 commands:
   playertimelimit:


### PR DESCRIPTION
## Summary

This PR fixes a timing/permission window where `PlayerTimeLimit` could incorrectly fall back to `default` before players authenticate with AuthMe (`join -> /login`).

It also removes an unsafe async permission check path and makes limit recalculation/auth synchronization deterministic.

## Problem

On AuthMe servers, players are online before being authenticated.  
During that pre-auth window:

- limit recalculation could run with incomplete/default permission state
- `time_limit` could be set to `default`
- remaining time UI and behavior became inconsistent until later updates

Additionally, `PlayerUpdateLimitTask` was running asynchronously while calling `player.hasPermission(...)`, which is not a safe pattern for Bukkit player state access.

## Changes

### 1) Main-thread limit recalculation
- Changed `PlayerUpdateLimitTask` from:
  - `runTaskTimerAsynchronously(...)`
  - to `runTaskTimer(...)`

### 2) Auth-aware readiness guard
- Added `isReadyForTimeTracking(Player)` in `PlayerDataManager`.
- Behavior:
  - If AuthMe is not installed: returns `true`
  - If AuthMe is installed: returns `true` only when:
    - player is authenticated, or
    - player is not registered

### 3) Pause pre-auth mutations
- `PlayerTimeTask.execute()` now skips players not ready for tracking.
- `PlayerUpdateLimitTask.execute()` now skips limit recalculation for players not ready.
- `manageJoin(...)` no longer forces `updateTimeLimit(...)` before auth readiness.

### 4) Immediate recalc on auth events
- Added new integration class: `AuthMeSupport`
- Registers optional listeners (via reflection) for:
  - `fr.xephi.authme.events.LoginEvent`
  - `fr.xephi.authme.events.RestoreSessionEvent`
  - `fr.xephi.authme.events.RegisterEvent`
- On these events:
  - recalculates limit immediately
  - refreshes info bars

### 5) Plugin metadata
- Added `AuthMe` to `softdepend` in `plugin.yml`

## Files changed

- `src/main/java/ptl/ajneb97/PlayerTimeLimit.java`
- `src/main/java/ptl/ajneb97/managers/PlayerDataManager.java`
- `src/main/java/ptl/ajneb97/tasks/PlayerTimeTask.java`
- `src/main/java/ptl/ajneb97/tasks/PlayerUpdateLimitTask.java`
- `src/main/java/ptl/ajneb97/integrations/AuthMeSupport.java` (new)
- `src/main/resources/plugin.yml`

## Compatibility

- No config format changes
- No command changes
- No DB schema changes
- Behavior is unchanged on servers without AuthMe (except safer main-thread limit task)

## Expected behavior after merge

- No more `default` limit overwrite during pre-login/auth window
- No time consumption before AuthMe authentication
- Correct role limit is applied immediately after `/login` or session restore
